### PR TITLE
:zap: :lock: Add Proptypes and fix target blank warning #30

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2826,6 +2826,15 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
       "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow=="
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "block-stream": {
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
@@ -5571,6 +5580,12 @@
         "schema-utils": "^2.5.0"
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
+    },
     "filesize": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/filesize/-/filesize-6.0.1.tgz",
@@ -7260,6 +7275,7 @@
           "integrity": "sha512-Ggd/Ktt7E7I8pxZRbGIs7vwqAPscSESMrCSkx2FtWeqmheJgCo2R74fTsZFCifr0VTPwqRpPv17+6b8Zp7th0Q==",
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1",
             "node-pre-gyp": "*"
           },
@@ -13903,6 +13919,7 @@
           "integrity": "sha512-Ggd/Ktt7E7I8pxZRbGIs7vwqAPscSESMrCSkx2FtWeqmheJgCo2R74fTsZFCifr0VTPwqRpPv17+6b8Zp7th0Q==",
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1",
             "node-pre-gyp": "*"
           },
@@ -14678,6 +14695,7 @@
           "integrity": "sha512-Ggd/Ktt7E7I8pxZRbGIs7vwqAPscSESMrCSkx2FtWeqmheJgCo2R74fTsZFCifr0VTPwqRpPv17+6b8Zp7th0Q==",
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1",
             "node-pre-gyp": "*"
           },

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@testing-library/user-event": "^7.2.1",
     "node": "^13.12.0",
     "node-sass": "^4.13.1",
+    "prop-types": "^15.7.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-scripts": "3.4.1"

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,58 +1,32 @@
-import React from 'react';
-import '../stylesheets/main.scss';
-import Header from './header';
-import Collapse from './collapse';
-import Footer from './footer';
-import Palettes from './Palettes';
-import Card from './Card';
-import Fill from './fill';
-import Share from './Share';
-import defaultImage from '../images/preview-photo.jpg';
+import React from "react";
+import "../stylesheets/main.scss";
+import Header from "./header";
+import Collapse from "./Collapse";
+import Footer from "./footer";
+import Palettes from "./Palettes";
+import Card from "./Card";
+import Fill from "./fill";
+import Share from "./Share";
+import defaultImage from "../images/preview-photo.jpg";
 
-// function App() {
-//   const [palette, setPalette] = useState('1');
-//   const [img, setImg] = useState(defaultImage);
-//   const handlePalette1 = (id) => {
-//     setPalette(id);
-//   };
-//   const handleImg = (img) => {
-//     setImg(img);
-//   };
-//   return (
-//     <div /* className="App" */>
-//       <Header />
-//       <main className='main'>
-//         <Card statePalette={palette} stateImg={img} handleImg={handleImg} />
-//         <Collapse title='Diseña' icon='far fa-object-ungroup' />
-//         <Palettes handleChange={handlePalette1} />
-//         <Collapse title='Rellena' icon='far fa-keyboard'>
-//           <Fill handleImg={handleImg}></Fill>
-//         </Collapse>
-//         <Collapse title='Comparte' icon='fas fa-share-alt'>
-//           <Share />
-//         </Collapse>
-//       </main>
-//       <Footer />
-//     </div>
-//   );
 class App extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      palette: '1',
-      arrow1: '',
-      arrow2: 'closed',
-      arrow3: 'closed',
-      colStyle1: '',
-      colStyle2: 'hidden',
-      colStyle3: 'hidden',
-      name: '',
-      job: '',
-      phone: '',
+      palette: "1",
+      arrow1: "",
+      arrow2: "closed",
+      arrow3: "closed",
+      colStyle1: "",
+      colStyle2: "hidden",
+      colStyle3: "hidden",
+      name: "",
+      job: "",
+      phone: "",
       img: defaultImage,
-      email: '',
-      linkedin: '',
-      github: '',
+      email: "",
+      linkedin: "",
+      github: "",
     };
     this.handlePalette1 = this.handlePalette1.bind(this);
     this.handleCollapse1 = this.handleCollapse1.bind(this);
@@ -70,20 +44,20 @@ class App extends React.Component {
   handleCollapse1 = (id) => {
     this.setState((prevState, props) => {
       let style;
-      if (prevState.arrow1 === '') {
-        style = 'closed';
+      if (prevState.arrow1 === "") {
+        style = "closed";
       } else {
-        style = '';
+        style = "";
       }
       return { arrow1: style };
     });
 
     this.setState((prevState, props) => {
       let style;
-      if (prevState.colStyle1 === '') {
-        style = 'hidden';
+      if (prevState.colStyle1 === "") {
+        style = "hidden";
       } else {
-        style = '';
+        style = "";
       }
       return { colStyle1: style };
     });
@@ -92,19 +66,19 @@ class App extends React.Component {
   handleCollapse2 = (id) => {
     this.setState((prevState, props) => {
       let style;
-      if (prevState.arrow2 === '') {
-        style = 'closed';
+      if (prevState.arrow2 === "") {
+        style = "closed";
       } else {
-        style = '';
+        style = "";
       }
       return { arrow2: style };
     });
     this.setState((prevState, props) => {
       let style;
-      if (prevState.colStyle2 === '') {
-        style = 'hidden';
+      if (prevState.colStyle2 === "") {
+        style = "hidden";
       } else {
-        style = '';
+        style = "";
       }
       return { colStyle2: style };
     });
@@ -112,19 +86,19 @@ class App extends React.Component {
   handleCollapse3 = (id) => {
     this.setState((prevState, props) => {
       let style;
-      if (prevState.arrow3 === '') {
-        style = 'closed';
+      if (prevState.arrow3 === "") {
+        style = "closed";
       } else {
-        style = '';
+        style = "";
       }
       return { arrow3: style };
     });
     this.setState((prevState, props) => {
       let style;
-      if (prevState.colStyle3 === '') {
-        style = 'hidden';
+      if (prevState.colStyle3 === "") {
+        style = "hidden";
       } else {
-        style = '';
+        style = "";
       }
       return { colStyle3: style };
     });
@@ -142,16 +116,16 @@ class App extends React.Component {
     return (
       <div>
         <Header />
-        <main className='main'>
+        <main className="main">
           <Card stateImg={this.state.img} statePalette={this.state.palette} InputState={this.state} />
-          <section className='information'>
-            <Collapse close={this.state.arrow1} id='collapse-1' title='Diseña' icon='far fa-object-ungroup' handleCollapse={this.handleCollapse1}>
+          <section className="information">
+            <Collapse close={this.state.arrow1} id="collapse-1" title="Diseña" icon="far fa-object-ungroup" handleCollapse={this.handleCollapse1}>
               <Palettes handleChange={this.handlePalette1} display={this.state.colStyle1} />
             </Collapse>
-            <Collapse close={this.state.arrow2} id='collapse-2' title='Rellena' icon='far fa-keyboard' handleCollapse={this.handleCollapse2}>
+            <Collapse close={this.state.arrow2} id="collapse-2" title="Rellena" icon="far fa-keyboard" handleCollapse={this.handleCollapse2}>
               <Fill handleImg={this.handleImg} display={this.state.colStyle2} handleInfoUser={this.handleInfoUser} InputState={this.state}></Fill>
             </Collapse>
-            <Collapse close={this.state.arrow3} id='collapse-3' title='Comparte' icon='fas fa-share-alt' handleCollapse={this.handleCollapse3}>
+            <Collapse close={this.state.arrow3} id="collapse-3" title="Comparte" icon="fas fa-share-alt" handleCollapse={this.handleCollapse3}>
               <Share display={this.state.colStyle3} />
             </Collapse>
           </section>

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -1,4 +1,5 @@
-import React from 'react';
+import React from "react";
+import PropTypes from "prop-types";
 
 const Button = (props) => {
   return (
@@ -9,3 +10,8 @@ const Button = (props) => {
 };
 
 export default Button;
+Button.propTypes = {
+  buttonClass: PropTypes.string,
+  iconClass: PropTypes.string,
+  text: PropTypes.string,
+};

--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -1,23 +1,24 @@
-import React from 'react';
-import CardIcons from './CardIcons';
+import React from "react";
+import CardIcons from "./CardIcons";
+import PropTypes from "prop-types";
 
 const Card = (props) => {
   return (
-    <section className='card-sample'>
-      <div className='card-sample--container'>
-        <button className='card-sample--button'>
-          <i className='far fa-trash-alt'></i> Reset
+    <section className="card-sample">
+      <div className="card-sample--container">
+        <button className="card-sample--button">
+          <i className="far fa-trash-alt"></i> Reset
         </button>
-        <div className='card-sample--card'>
-          <h2 className={`card-sample--card__title title--palette-${props.statePalette}`}>{props.InputState.name || 'Nombre Apellidos'}</h2>
-          <h3 className={`card-sample--card__subtitle subtitle--palette-${props.statePalette}`}>{props.InputState.job || 'Front-end Developer'}</h3>
-          <div className='card-sample--card__img-cont'>
-            <img className='card-sample--card__img' src={props.stateImg} alt='imagen de ejemplo' />
+        <div className="card-sample--card">
+          <h2 className={`card-sample--card__title title--palette-${props.statePalette}`}>{props.InputState.name || "Nombre Apellidos"}</h2>
+          <h3 className={`card-sample--card__subtitle subtitle--palette-${props.statePalette}`}>{props.InputState.job || "Front-end Developer"}</h3>
+          <div className="card-sample--card__img-cont">
+            <img className="card-sample--card__img" src={props.stateImg} alt="imagen de ejemplo" />
           </div>
-          <CardIcons classLink={`card-sample--item__link1 link--palette-${props.statePalette}`} icon='fas fa-mobile-alt' url={`tel:${props.InputState.phone}`} />
-          <CardIcons classLink={`card-sample--item__link2 link--palette-${props.statePalette}`} icon='far fa-envelope' url={`mailto:${props.InputState.email}`} />
-          <CardIcons classLink={`card-sample--item__link3 link--palette-${props.statePalette}`} icon='fab fa-linkedin-in' url={`https://www.linkedin.com/in/${props.InputState.linkedin}`} />
-          <CardIcons classLink={`card-sample--item__link4 link--palette-${props.statePalette}`} icon='fab fa-github-alt' url={`https://www.github.com/${props.InputState.github}`} />
+          <CardIcons classLink={`card-sample--item__link1 link--palette-${props.statePalette}`} icon="fas fa-mobile-alt" url={`tel:${props.InputState.phone}`} />
+          <CardIcons classLink={`card-sample--item__link2 link--palette-${props.statePalette}`} icon="far fa-envelope" url={`mailto:${props.InputState.email}`} />
+          <CardIcons classLink={`card-sample--item__link3 link--palette-${props.statePalette}`} icon="fab fa-linkedin-in" url={`https://www.linkedin.com/in/${props.InputState.linkedin}`} />
+          <CardIcons classLink={`card-sample--item__link4 link--palette-${props.statePalette}`} icon="fab fa-github-alt" url={`https://www.github.com/${props.InputState.github}`} />
         </div>
       </div>
     </section>
@@ -25,3 +26,8 @@ const Card = (props) => {
 };
 
 export default Card;
+Card.propTypes = {
+  statePalette: PropTypes.string,
+  InputState: PropTypes.object,
+  stateImg: PropTypes.string,
+};

--- a/src/components/CardIcons.js
+++ b/src/components/CardIcons.js
@@ -1,12 +1,19 @@
-import React from 'react';
+import React from "react";
+import PropTypes from "prop-types";
 
 const CardIcons = (props) => {
   return (
     <div className="card-sample--item">
-      <a className={props.classLink} href={props.url} target="_blank">
+      <a className={props.classLink} href={props.url} target="_blank" rel="noopener noreferrer">
         <i className={props.icon}></i>
       </a>
     </div>
   );
 };
 export default CardIcons;
+
+CardIcons.propTypes = {
+  classLink: PropTypes.string,
+  url: PropTypes.string,
+  icon: PropTypes.string,
+};

--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -1,6 +1,7 @@
-import React from 'react';
-import Input from './input';
-import defaultImage from '../images/preview-photo.jpg';
+import React from "react";
+import Input from "./input";
+import defaultImage from "../images/preview-photo.jpg";
+import PropTypes from "prop-types";
 
 const fr = new FileReader();
 class Image extends React.Component {
@@ -16,7 +17,7 @@ class Image extends React.Component {
 
   handleImg() {
     const myFile = this.fileInput.current.files[0];
-    fr.addEventListener('load', this.writeImg);
+    fr.addEventListener("load", this.writeImg);
     fr.readAsDataURL(myFile);
   }
 
@@ -30,13 +31,13 @@ class Image extends React.Component {
   render() {
     return (
       <>
-        <div className='form--file'>
-          <Input className='form--file__input' type='file' name='form--file' />
-          <input onChange={this.handleImg} ref={this.fileInput} className='form--file__input js-fill-file' type='file' accept='image/png, .jpeg, .jpg, image/gif' />
+        <div className="form--file">
+          <Input className="form--file__input" type="file" name="form--file" />
+          <input onChange={this.handleImg} ref={this.fileInput} className="form--file__input js-fill-file" type="file" accept="image/png, .jpeg, .jpg, image/gif" />
         </div>
-        <div className='form--button__container'>
-          <button className='form--button'>Añadir imagen</button>
-          <img src={this.state.img} className='form--button__box' alt='previsualización de la imagen' />
+        <div className="form--button__container">
+          <button className="form--button">Añadir imagen</button>
+          <img src={this.state.img} className="form--button__box" alt="previsualización de la imagen" />
         </div>
       </>
     );
@@ -44,3 +45,7 @@ class Image extends React.Component {
 }
 
 export default Image;
+
+Image.propTypes = {
+  handleImg: PropTypes.func,
+};

--- a/src/components/Palettes-color-radio.js
+++ b/src/components/Palettes-color-radio.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 
 const ColorsRadio = (props) => {
   return (
@@ -10,3 +11,9 @@ const ColorsRadio = (props) => {
   );
 };
 export default ColorsRadio;
+ColorsRadio.propTypes = {
+  paletteClass: PropTypes.string,
+  colorA: PropTypes.string,
+  ColorB: PropTypes.string,
+  ColorC: PropTypes.string,
+};

--- a/src/components/Palettes-radio.js
+++ b/src/components/Palettes-radio.js
@@ -1,5 +1,6 @@
-import React from 'react';
-import ColorsRadio from './Palettes-color-radio';
+import React from "react";
+import ColorsRadio from "./Palettes-color-radio";
+import PropTypes from "prop-types";
 
 const Radio = (props) => {
   const handleChange = (ev) => {
@@ -7,11 +8,20 @@ const Radio = (props) => {
   };
 
   return (
-    <label className='design--form__item' htmlFor={props.id}>
-      <input id={props.id} className={props.className} type='radio' name='select-palette' onChange={handleChange} />
+    <label className="design--form__item" htmlFor={props.id}>
+      <input id={props.id} className={props.className} type="radio" name="select-palette" onChange={handleChange} />
       <ColorsRadio paletteClass={props.paletteClass} colorA={props.colorA} colorB={props.colorB} colorC={props.colorC} />
     </label>
   );
 };
 
 export default Radio;
+Radio.propTypes = {
+  handlePalette1: PropTypes.func,
+  id: PropTypes.string,
+  className: PropTypes.string,
+  paletteClass: PropTypes.string,
+  colorA: PropTypes.string,
+  ColorB: PropTypes.string,
+  ColorC: PropTypes.string,
+};

--- a/src/components/Palettes.js
+++ b/src/components/Palettes.js
@@ -1,17 +1,18 @@
-import React from 'react';
-import Radio from './Palettes-radio';
+import React from "react";
+import Radio from "./Palettes-radio";
+import PropTypes from "prop-types";
 
 const Palettes = (props) => {
   return (
-    <section className='design'>
+    <section className="design">
       <div className={`design--container__2 ${props.display}`}>
-        <p className='design--subtitle'>Colores</p>
-        <form className='js-form design--form' action='' method='GET'>
-          <Radio id='1' paletteClass='design--palette1' colorA='design--palette1__colorA' colorB='design--palette1__colorB' colorC='design--palette1__colorC' handlePalette1={props.handleChange} />
+        <p className="design--subtitle">Colores</p>
+        <form className="js-form design--form" action="" method="GET">
+          <Radio id="1" paletteClass="design--palette1" colorA="design--palette1__colorA" colorB="design--palette1__colorB" colorC="design--palette1__colorC" handlePalette1={props.handleChange} />
 
-          <Radio id='2' paletteClass='design--palette2' colorA='design--palette2__colorA' colorB='design--palette2__colorB' colorC='design--palette2__colorC' handlePalette1={props.handleChange} />
+          <Radio id="2" paletteClass="design--palette2" colorA="design--palette2__colorA" colorB="design--palette2__colorB" colorC="design--palette2__colorC" handlePalette1={props.handleChange} />
 
-          <Radio id='3' paletteClass='design--palette3' colorA='design--palette3__colorA' colorB='design--palette3__colorB' colorC='design--palette3__colorC' handlePalette1={props.handleChange} />
+          <Radio id="3" paletteClass="design--palette3" colorA="design--palette3__colorA" colorB="design--palette3__colorB" colorC="design--palette3__colorC" handlePalette1={props.handleChange} />
         </form>
       </div>
     </section>
@@ -19,3 +20,7 @@ const Palettes = (props) => {
 };
 
 export default Palettes;
+Palettes.propTypes = {
+  display: PropTypes.string,
+  handleChange: PropTypes.func,
+};

--- a/src/components/Share.js
+++ b/src/components/Share.js
@@ -1,19 +1,20 @@
-import React from 'react';
-import Button from './Button';
+import React from "react";
+import Button from "./Button";
+import PropTypes from "prop-types";
 const Share = (props) => {
   return (
-    <section className='section--share'>
+    <section className="section--share">
       {/* <!-- Boton --> */}
       <div className={`js-share--div ${props.display}`}>
-        <div className='share--button__container'>
-          <Button buttonClass='share--button js-btn' iconClass='far fa-address-card' text='Crear tarjeta' />
+        <div className="share--button__container">
+          <Button buttonClass="share--button js-btn" iconClass="far fa-address-card" text="Crear tarjeta" />
         </div>
         {/* <!-- Tarjeta Creada --> */}
-        <div className='share--card--created js-card-created'>
-          <div className='share--card--created--text'>La tarjeta ha sido creada</div>
-          <div className='share--card--created--awesome-prof js-share-url'>url creada</div>
-          <div className='share--card--created--button__container'></div>
-          <Button buttonClass='share--card--created--button' href='https://twitter.com/intent/tweet?text=Hey!%20Mira%20que%20tarjeta%20he%20creado' iconClass='fab fa-twitter' text='Compartir en twitter' />
+        <div className="share--card--created js-card-created">
+          <div className="share--card--created--text">La tarjeta ha sido creada</div>
+          <div className="share--card--created--awesome-prof js-share-url">url creada</div>
+          <div className="share--card--created--button__container"></div>
+          <Button buttonClass="share--card--created--button" href="https://twitter.com/intent/tweet?text=Hey!%20Mira%20que%20tarjeta%20he%20creado" iconClass="fab fa-twitter" text="Compartir en twitter" />
         </div>
       </div>
     </section>
@@ -21,3 +22,6 @@ const Share = (props) => {
 };
 
 export default Share;
+Share.propTypes = {
+  display: PropTypes.string,
+};

--- a/src/components/collapse.js
+++ b/src/components/collapse.js
@@ -1,4 +1,5 @@
-import React from 'react';
+import React from "react";
+import PropTypes from "prop-types";
 
 const Collapse = (props) => {
   function handleClick(ev) {
@@ -9,12 +10,12 @@ const Collapse = (props) => {
 
   return (
     <section>
-      <div id={props.id} onClick={handleClick} className='share js-share-title'>
-        <span className='share--icon1'>
+      <div id={props.id} onClick={handleClick} className="share js-share-title">
+        <span className="share--icon1">
           <i className={props.icon}></i>
         </span>
-        <h3 className='share--text'>{props.title}</h3>
-        <a href='/' className='share--icon2'>
+        <h3 className="share--text">{props.title}</h3>
+        <a href="/" className="share--icon2">
           <i className={`js-arrow fas fa-angle-up ${props.close}`}></i>
         </a>
       </div>
@@ -24,3 +25,10 @@ const Collapse = (props) => {
 };
 
 export default Collapse;
+Collapse.propTypes = {
+  id: PropTypes.string,
+  icon: PropTypes.string,
+  title: PropTypes.string,
+  close: PropTypes.string,
+  children: PropTypes.any,
+};

--- a/src/components/fill.js
+++ b/src/components/fill.js
@@ -1,38 +1,40 @@
-import React from 'react';
-import Input from './input';
-import Label from './label';
-import Image from './Image';
+import React from "react";
+import Input from "./input";
+import Label from "./label";
+import Image from "./Image";
+import PropTypes from "prop-types";
+
 const Fill = (props) => {
   return (
-    <section className='section--fill'>
+    <section className="section--fill">
       <div className={`js-fill--div ${props.display}`}>
         {/* <!-- Formulario --> */}
         {/* handleImg={props.handleImg} */}
-        <form className='js-form form' action='/signup' method='post'>
-          <Label For='form--name' text=' Nombre completo' />
-          <Input id='form--name' type='text' name='name' placeholder='Ej: Sally Jill' handleInfoUser={props.handleInfoUser} value={props.InputState.name} />
+        <form className="js-form form" action="/signup" method="post">
+          <Label For="form--name" text=" Nombre completo" />
+          <Input id="form--name" type="text" name="name" placeholder="Ej: Sally Jill" handleInfoUser={props.handleInfoUser} value={props.InputState.name} />
 
-          <Label For='form--job' text='Puesto' />
-          <Input id='form--job' type='text' name='job' placeholder='Ej: Front-end unicorn' handleInfoUser={props.handleInfoUser} value={props.InputState.job} />
+          <Label For="form--job" text="Puesto" />
+          <Input id="form--job" type="text" name="job" placeholder="Ej: Front-end unicorn" handleInfoUser={props.handleInfoUser} value={props.InputState.job} />
 
-          <Label For='form--img' text='Imagen de perfil' />
-          <div className='form--file'>
+          <Label For="form--img" text="Imagen de perfil" />
+          <div className="form--file">
             <Image handleImg={props.handleImg} />
             {/* <Input className="form--file__input" type="file" name="photo" handleImg={props.handleImg}/> */}
             {/* <input className='form--file__input js-fill-file' type='file' accept='image/png, .jpeg, .jpg, image/gif' /> */}
           </div>
 
-          <Label For='form--email' text='Email' />
-          <Input id='form--email' type='email' name='email' placeholder='Ej: sally-hill@gmail.com' handleInfoUser={props.handleInfoUser} value={props.InputState.email} />
+          <Label For="form--email" text="Email" />
+          <Input id="form--email" type="email" name="email" placeholder="Ej: sally-hill@gmail.com" handleInfoUser={props.handleInfoUser} value={props.InputState.email} />
 
-          <Label For='form--phone' text='Teléfono' />
-          <Input id='form--phone' type='tel' name='phone' placeholder='555-55-55-55' handleInfoUser={props.handleInfoUser} value={props.InputState.phone} />
+          <Label For="form--phone" text="Teléfono" />
+          <Input id="form--phone" type="tel" name="phone" placeholder="555-55-55-55" handleInfoUser={props.handleInfoUser} value={props.InputState.phone} />
 
-          <Label For='form--linkedin' text='Linkjedin' />
-          <Input id='form--linkedin' type='text' name='linkedin' placeholder='Ej: linkedin.com/in/sally.hill' handleInfoUser={props.handleInfoUser} value={props.InputState.linkedin} />
+          <Label For="form--linkedin" text="Linkjedin" />
+          <Input id="form--linkedin" type="text" name="linkedin" placeholder="Ej: linkedin.com/in/sally.hill" handleInfoUser={props.handleInfoUser} value={props.InputState.linkedin} />
 
-          <Label For='form--github' text='Github' />
-          <Input id='form--github' type='text' name='github' placeholder='Ej: github.com/sally-hill' handleInfoUser={props.handleInfoUser} value={props.InputState.github} />
+          <Label For="form--github" text="Github" />
+          <Input id="form--github" type="text" name="github" placeholder="Ej: github.com/sally-hill" handleInfoUser={props.handleInfoUser} value={props.InputState.github} />
         </form>
       </div>
     </section>
@@ -40,3 +42,9 @@ const Fill = (props) => {
 };
 
 export default Fill;
+Fill.propTypes = {
+  display: PropTypes.string,
+  handleInfoUser: PropTypes.func,
+  InputState: PropTypes.object,
+  handleImg: PropTypes.func,
+};

--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -1,21 +1,19 @@
-import React from 'react';
-import AdalabLogo from '../images/logo-adalab.png';
+import React from "react";
+import AdalabLogo from "../images/logo-adalab.png";
 
 const Footer = () => {
-  return(
-  <footer>
-  <div className="footer">
-    <div className="footer--title">
-      <small>
-        Awesome profile-cards @2018
-      </small>
-    </div>
-    <div>
-      <img className="footer--logo" src={AdalabLogo} alt="Logo Adalab" />
-    </div>
-  </div>
-</footer>
-);
-}
+  return (
+    <footer>
+      <div className="footer">
+        <div className="footer--title">
+          <small>Awesome profile-cards @2018</small>
+        </div>
+        <div>
+          <img className="footer--logo" src={AdalabLogo} alt="Logo Adalab" />
+        </div>
+      </div>
+    </footer>
+  );
+};
 
-export default Footer; 
+export default Footer;

--- a/src/components/input.js
+++ b/src/components/input.js
@@ -1,4 +1,5 @@
-import React from 'react';
+import React from "react";
+import PropTypes from "prop-types";
 
 class Input extends React.Component {
   handleInfoUser = (ev) => {
@@ -12,3 +13,12 @@ class Input extends React.Component {
   }
 }
 export default Input;
+Input.propTypes = {
+  className: PropTypes.string,
+  id: PropTypes.string,
+  type: PropTypes.string,
+  name: PropTypes.string,
+  placeholder: PropTypes.string,
+  value: PropTypes.string,
+  handleInfoUser: PropTypes.func,
+};

--- a/src/components/label.js
+++ b/src/components/label.js
@@ -1,9 +1,15 @@
-import React from 'react';
-const Label = props => {
+import React from "react";
+import PropTypes from "prop-types";
+
+const Label = (props) => {
   return (
     <label htmlFor={props.For}>
-      {props.text} <span className='form-object'> *</span>
+      {props.text} <span className="form-object"> *</span>
     </label>
   );
 };
 export default Label;
+Label.propTypes = {
+  For: PropTypes.string,
+  text: PropTypes.string,
+};


### PR DESCRIPTION
He añadido los propTypes a todos los componentes y he investigado el warning del `target=blank`. 

Resumo `target=blank` básicamente, lo que pasa es que al abrir en otra pestaña, creamos vulnerabilidades para que se nos metan. Por eso, al poner `rel="noopener noreferrer"` le estamos diciendo que no puedan meter desde la nueva pestaña nada en la que teníamos antes abierta ("noopener")y que los datos que estén metidos en la pestaña original no vayan a la nueva ("noreferrer"), más o menos (artículo por si no me he explicado bien: https://reinspirit.com/etiqueta-rel-noopener-wordpress/